### PR TITLE
🩻 Add AWS X-Ray

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,3 +20,10 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_readonly_access" {
   role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "xray_readonly_access" {
+  count = var.enable_xray ? 1 : 0
+
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,14 @@ variable "observability_platform_account_id" {
   description = "Account ID of the Observability Platform environment. If you are running on Modernisation Platform you can use 'local.environment_management.account_ids[\"observability-platform-production\"]"
 }
 
+variable "enable_xray" {
+  type        = bool
+  description = "Enable AWS X-Ray's read only managed policy"
+  default     = false
+}
+
 variable "tags" {
   type        = map(string)
-  default     = {}
   description = "Tags to apply to resources"
+  default     = {}
 }


### PR DESCRIPTION
This pull request:

Relates to https://github.com/ministryofjustice/observability-platform/issues/10

- Adds AWS X-Ray's read only access managed policy as an opt-in feature
- Reorders arguments in `variable "tags" {}`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 