### PR TITLE
🧑‍🔬 Add support for additional IAM polices

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Upgrade Pip
-pip install --upgrade pip
+pip install --break-system-packages --upgrade pip
 
 # Install dependencies
-pip install --requirement requirements-dev.txt
+pip install --break-system-package --requirement requirements-dev.txt

--- a/main.tf
+++ b/main.tf
@@ -27,3 +27,10 @@ resource "aws_iam_role_policy_attachment" "xray_readonly_access" {
   role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "additional_policies" {
+  for_each = { for k, v in var.additional_policies : k => v }
+
+  role       = aws_iam_role.this.name
+  policy_arn = each.value
+}

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,13 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_readonly_access" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "amazon_prometheus_query_access" {
+  count = var.enable_prometheus ? 1 : 0
+
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "xray_readonly_access" {
   count = var.enable_xray ? 1 : 0
 

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -41,3 +41,13 @@ run "invalid_role_name" {
 
   expect_failures = [var.role_name]
 }
+
+run "additional_polcies" {
+  command = plan
+
+  variables {
+    additional_polcies = {
+      AmazonPrometheusQueryAccess = "arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
+    }
+  }
+}

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -47,7 +47,7 @@ run "additional_polcies" {
 
   variables {
     additional_polcies = {
-      AmazonPrometheusQueryAccess = "arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
+      AmazonDevOpsGuruReadOnlyAccess = "arn:aws:iam::aws:policy/AmazonDevOpsGuruReadOnlyAccess"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "enable_xray" {
   default     = false
 }
 
+variable "additional_policies" {
+  type        = map(string)
+  description = "ARNs of any policies to attach to the IAM role"
+  default     = {}
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to resources"

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,12 @@ variable "observability_platform_account_id" {
   }
 }
 
+variable "enable_prometheus" {
+  type        = bool
+  description = "Enable AWS Managed Prometheus' query access managed policy"
+  default     = false
+}
+
 variable "enable_xray" {
   type        = bool
   description = "Enable AWS X-Ray's read only managed policy"


### PR DESCRIPTION
This pull request:

Is part of https://github.com/ministryofjustice/observability-platform/issues/86

- Adds `enable_prometheus` to allow query access to remote Amazon Managed Prometheus workspaces
- Adds an optional `additional_policies` map to attach further polices to the IAM role
  - Primarily to provide access to any KMS keys used in tenant accounts, for example Amazon Managed Prometheus's encryption-at-rest using a CMK 

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>  