### PR TITLE
:wrench: Add ability to enable Athena Data Source

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:bb07a76c8e7a6b630a2056ce959addddee436e3f9936c69b9163eff54f58dbd5"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:af3b3891cf31ff373df29998c690257d6f21f2ee4536bc4d692856408ef0c83a",
-      "integrity": "sha256:af3b3891cf31ff373df29998c690257d6f21f2ee4536bc4d692856408ef0c83a"
+      "version": "1.1.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8",
+      "integrity": "sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8"
     }
   }
 }

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,3 +34,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
           VALIDATE_TERRAFORM_TERRASCAN: false
+          VALIDATE_TERRAGRUNT: false

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,64 @@ data "aws_iam_policy_document" "assume" {
   }
 }
 
+data "aws_iam_policy_document" "custom_athena_policy" {
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+  #checkov:skip=CKV_AWS_111
+  statement {
+    sid    = "AthenaQueryAccess"
+    effect = "Allow"
+    actions = [
+      "athena:ListDatabases",
+      "athena:ListDataCatalogs",
+      "athena:ListWorkGroups",
+      "athena:GetDatabase",
+      "athena:GetDataCatalog",
+      "athena:GetQueryExecution",
+      "athena:GetQueryResults",
+      "athena:GetTableMetadata",
+      "athena:GetWorkGroup",
+      "athena:ListTableMetadata",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "GlueReadAccess"
+    effect = "Allow"
+    actions = [
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetPartition",
+      "glue:GetPartitions",
+      "glue:BatchGetPartition"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "AthenaS3Access"
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload",
+      "s3:PutObject"
+    ]
+    resources = ["arn:aws:s3:::${var.grafana_athena_query_results_s3_bucket}"]
+  }
+  statement {
+    sid       = "AthenaCostUsageReportsAccess"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.cost_usage_reports_s3_bucket}"]
+  }
+}
+
 resource "aws_iam_role" "this" {
   name               = var.role_name
   path               = "/"
@@ -35,19 +93,11 @@ resource "aws_iam_role_policy_attachment" "xray_readonly_access" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
 }
 
-# resource "aws_iam_role_policy_attachment" "athena_readonly_access" {
-#   count = var.enable_athena ? 1 : 0
-
-#   role       = aws_iam_role.this.name
-#   policy_arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
-# }
-
-# this is purely for testing, at first glance there is not a read only policy for athena
-resource "aws_iam_role_policy_attachment" "athena_full_access" {
+resource "aws_iam_role_policy_attachment" "athena_custom_access" {
   count = var.enable_athena ? 1 : 0
 
   role       = aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+  policy_arn = data.aws_iam_policy_document.custom_athena_policy
 }
 
 resource "aws_iam_role_policy_attachment" "additional_policies" {

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,21 @@ resource "aws_iam_role_policy_attachment" "xray_readonly_access" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
 }
 
+# resource "aws_iam_role_policy_attachment" "athena_readonly_access" {
+#   count = var.enable_athena ? 1 : 0
+
+#   role       = aws_iam_role.this.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+# }
+
+# this is purely for testing, at first glance there is not a read only policy for athena
+resource "aws_iam_role_policy_attachment" "athena_full_access" {
+  count = var.enable_athena ? 1 : 0
+
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "additional_policies" {
   for_each = { for k, v in var.additional_policies : k => v }
 

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -16,6 +16,8 @@ provider "aws" {
 
 variables {
   observability_platform_account_id = "111111111111"
+  grafana_athena_query_results_s3_bucket = "query_results_s3_bucket"
+  cost_usage_reports_s3_bucket = "cost_usage_reports_s3_bucket"
 }
 
 run "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,20 +31,24 @@ variable "enable_xray" {
 
 variable "enable_athena" {
   type        = bool
-  description = "Enable AWS Athena Full managed policy"
+  description = "Enable AWS Athena custom policy"
   default     = false
 }
-
-# variable "enable_athena" {
-#   type        = bool
-#   description = "Enable custom Athena read only policy"
-#   default     = false
-# }
 
 variable "additional_policies" {
   type        = map(string)
   description = "ARNs of any policies to attach to the IAM role"
   default     = {}
+}
+
+variable "grafana_athena_query_results_s3_bucket" {
+  description = "The S3 bucket for Grafana Athena query results"
+  type        = string
+}
+
+variable "cost_usage_reports_s3_bucket" {
+  description = "The S3 bucket for Cost and Usage reports"
+  type        = string
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,18 @@ variable "enable_xray" {
   default     = false
 }
 
+variable "enable_athena" {
+  type        = bool
+  description = "Enable AWS Athena Full managed policy"
+  default     = false
+}
+
+# variable "enable_athena" {
+#   type        = bool
+#   description = "Enable custom Athena read only policy"
+#   default     = false
+# }
+
 variable "additional_policies" {
   type        = map(string)
   description = "ARNs of any policies to attach to the IAM role"


### PR DESCRIPTION
Raised in relation to [this](https://github.com/ministryofjustice/analytical-platform/issues/5382) piece of work and is being raised in conjunction with [this PR](https://github.com/ministryofjustice/modernisation-platform-environments/pull/8142) in the Modernisation Platform Environments repository.

The purpose of this PR is to allow users to consume Athena as a Data source when using this terraform module to onboard to the Observability Platform.

Note: 
- Custom Access policy as I cannot see a comparable AWS Managed read-only one.
- [Issue](https://github.com/ministryofjustice/observability-platform/issues/136) created to update docs 
- `VALIDATE_TERRAGRUNT: false` added to the superlinter workflow as I cannot see a way to resolve the following error:

```bash 
time=2024-10-09T12:52:52Z level=error msg=Invalid file format /github/workspace/tests/main.tftest.hcl
time=2024-10-09T12:52:52Z level=error msg=Unable to determine underlying exit code, so Terragrunt will exit with error code 1
```